### PR TITLE
remove date shown on "no results" response

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -73,9 +73,6 @@ client.on("messageCreate", async (msg: Message) => {
                   value:
                     "Torrent not found on 1337x, please refine your search.",
                 },
-              ])
-              .setFooter(Date()),
-          ],
         });
       }
 


### PR DESCRIPTION
it is irrelevant due to the fact that discord shows when a message was sent, and also by the fact that other replies by the bot do not show the date.
also makes the response smaller.
![image](https://user-images.githubusercontent.com/53054786/156885460-3195a611-58c0-4f12-b7d2-e68c127f4c04.png)
